### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lukeponga-dev/lukeponga-dev.github.io/security/code-scanning/1](https://github.com/lukeponga-dev/lukeponga-dev.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and builds the project, it likely only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to perform the workflow tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
